### PR TITLE
Fix typo in login.jsx handler name

### DIFF
--- a/src/docker-frontend-backend-db/frontend/src/components/login.jsx
+++ b/src/docker-frontend-backend-db/frontend/src/components/login.jsx
@@ -3,7 +3,7 @@ const apiUri = process.env.API_URL;
 
 const Login = () => {
   let loading = false;
-  const handleChaange = () => { };
+  const handleChange = () => { };
   const handleSubmit = () => { };
   return (
     <div>LOGIN</div>


### PR DESCRIPTION
## Summary
- correct function name `handleChaange` to `handleChange` in `login.jsx`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_683f40f92394832192d53de2e7bca0d5